### PR TITLE
Implementation of businessrules task 5 6

### DIFF
--- a/Assignment3.Entities.Tests/TaskRepositoryTests.cs
+++ b/Assignment3.Entities.Tests/TaskRepositoryTests.cs
@@ -126,7 +126,9 @@ public class TaskRepositoryTests
 
         var stateUpdated = response.StateUpdated;
 
+        bool updateIsAfterExpected = expected < stateUpdated;
         //Assert
         Assert.Equal(expected, stateUpdated, precision: TimeSpan.FromSeconds(1)); // If new updated time was within 1 second.
+        Assert.Equal(true, updateIsAfterExpected); // Since expected is made before the update happens, we expect its value to be less (meaning the actual was actually updated).
     }
 }

--- a/Assignment3.Entities/Task.cs
+++ b/Assignment3.Entities/Task.cs
@@ -23,6 +23,7 @@ public class Task
     {
         Title = title;
         State = Assignment3.Core.State.New; //This should probably be set but I suppose it can just be updated later
+        Updated = DateTime.Now;
         Tags = new List<Tag>();
     }
 

--- a/Assignment3.Entities/TaskRepository.cs
+++ b/Assignment3.Entities/TaskRepository.cs
@@ -121,6 +121,15 @@ public class TaskRepository : Assignment3.Core.ITaskRepository
     public Response Update(TaskUpdateDTO task)
     {
         var entity = _context.Tasks.Find(task.Id);
+
+        // Get all tags from task
+        var allTags = new List<Tag> {};
+        foreach(string s in task.Tags) {
+            int sInt = int.Parse(s);
+            var tag = _context.Tags.Find(sInt);
+            if (tag != null) allTags.Add(tag);
+        }
+
         Response response;
 
         if (entity is null) 
@@ -134,6 +143,9 @@ public class TaskRepository : Assignment3.Core.ITaskRepository
         else 
         {
             entity.Title = task.Title;
+            entity.Tags = allTags;
+            entity.State = task.State;
+            entity.Updated = DateTime.UtcNow;
             _context.SaveChanges();
             response = Response.Updated;
         }

--- a/Assignment3.Entities/TaskRepository.cs
+++ b/Assignment3.Entities/TaskRepository.cs
@@ -144,8 +144,10 @@ public class TaskRepository : Assignment3.Core.ITaskRepository
         {
             entity.Title = task.Title;
             entity.Tags = allTags;
+            if (task.State != entity.State) {   //Only update "updated" if state is changed
+                entity.Updated = DateTime.UtcNow;
+            }
             entity.State = task.State;
-            entity.Updated = DateTime.UtcNow;
             _context.SaveChanges();
             response = Response.Updated;
         }


### PR DESCRIPTION
Update method, now also updates tags (as specified in
 rule 2.5) and the 'Updated' field to current time (as specified in rule 2.6)